### PR TITLE
fix(docs): expose FalkorDB browser on port 3000, clarify API key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Inspired by the [Mem0 × OpenClaw blog post](https://mem0.ai/blog/mem0-memory-fo
 docker compose up -d
 ```
 
+FalkorDB Browser is available at [http://localhost:3000](http://localhost:3000).
+
 Or without Docker Compose:
 ```bash
-docker run --rm -p 6379:6379 falkordb/falkordb:latest
+docker run --rm -p 6379:6379 -p 3000:3000 falkordb/falkordb:latest
 ```
 
 ### 2. Install dependencies
@@ -57,7 +59,11 @@ pip install mem0ai mem0-falkordb openai falkordb rich python-dotenv
 
 ```bash
 cp .env.example .env
-# Edit .env and add your OpenAI API key
+```
+
+Edit `.env` and set your **real** OpenAI API key:
+```env
+OPENAI_API_KEY=sk-proj-...
 ```
 
 ### 4. Run!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,5 @@ services:
     image: falkordb/falkordb:latest
     ports:
       - "6379:6379"
+      - "3000:3000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Expose the FalkorDB Browser UI and make the setup instructions clearer.

## Changes
- `docker-compose.yml`: add port `3000:3000` for the FalkorDB Browser
- `README.md`: add browser URL, clarify API key format with example, update standalone docker run command

## Testing
N/A — docs and config only

## Memory / Performance Impact
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start guide to expose FalkorDB Browser at http://localhost:3000
  * Enhanced OpenAI API key configuration instructions with clearer formatting

* **Configuration**
  * Added port 3000 mapping to Docker setup for web UI accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->